### PR TITLE
Ros2 enhancement add imu output

### DIFF
--- a/vesc_driver/99-vesc6.rules
+++ b/vesc_driver/99-vesc6.rules
@@ -1,0 +1,10 @@
+# Device vesc6 udev definition
+# idVendor  0x0403
+# idProduct 0x5740
+
+
+# Alias the Sparkfun 9DoF as imu, and the electronic speed controller as VESC
+#ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9d0f", SYMLINK+="imu" , GROUP="dialout"
+#ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", SYMLINK+="vesc%n", GROUP="dialout"
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740",PROGRAM="/bin/vesc_device_lookup %k", SYMLINK+="vesc/%c", GROUP=$
+

--- a/vesc_driver/CMakeLists.txt
+++ b/vesc_driver/CMakeLists.txt
@@ -36,6 +36,14 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE ${PROJECT_NAME}_node
 )
 
+#add_executable(vesc_device_namer src/vesc_device_namer.cpp src/vesc_device_uuid_lookup.cpp)
+ament_auto_add_executable(vesc_device_namer src/vesc_device_namer.cpp src/vesc_device_uuid_lookup.cpp)
+
+target_link_libraries(vesc_device_namer 
+  ${Boost_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
+  )
+
 #############
 ## Testing ##
 #############

--- a/vesc_driver/include/vesc_driver/datatypes.hpp
+++ b/vesc_driver/include/vesc_driver/datatypes.hpp
@@ -28,24 +28,29 @@
 
 
 /*
-  Some parts of this code, Copyright 2016 - 2017 Benjamin Vedder benjamin@vedder.se
+  Some parts of this code, Copyright 2016 - 2019 Benjamin Vedder	benjamin@vedder.se
 
-  VESC Tool is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+	This file is part of the VESC firmware.
 
-  VESC Tool is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+	The VESC firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+    The VESC firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-#ifndef VESC_DRIVER__DATATYPES_HPP_
-#define VESC_DRIVER__DATATYPES_HPP_
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+
+#ifndef DATATYPES_H_
+#define DATATYPES_H_
+
+#include <stdint.h>
+#include <stdbool.h>
 
 #include <cstdint>
 
@@ -81,139 +86,961 @@ typedef enum
   VESC_TX_DOUBLE16,
   VESC_TX_DOUBLE32,
   VESC_TX_DOUBLE32_AUTO
+} VESC_TX_T;
+
+//#include "ch.h"
+typedef uint32_t systime_t; // defined in ch.h
+
+// Data types
+typedef enum {
+   MC_STATE_OFF = 0,
+   MC_STATE_DETECTING,
+   MC_STATE_RUNNING,
+   MC_STATE_FULL_BRAKE,
+} mc_state;
+
+typedef enum {
+	PWM_MODE_NONSYNCHRONOUS_HISW = 0, // This mode is not recommended
+	PWM_MODE_SYNCHRONOUS, // The recommended and most tested mode
+	PWM_MODE_BIPOLAR // Some glitches occasionally, can kill MOSFETs
+} mc_pwm_mode;
+
+typedef enum {
+	COMM_MODE_INTEGRATE = 0,
+	COMM_MODE_DELAY
+} mc_comm_mode;
+
+typedef enum {
+	SENSOR_MODE_SENSORLESS = 0,
+	SENSOR_MODE_SENSORED,
+	SENSOR_MODE_HYBRID
+} mc_sensor_mode;
+
+typedef enum {
+	FOC_SENSOR_MODE_SENSORLESS = 0,
+	FOC_SENSOR_MODE_ENCODER,
+	FOC_SENSOR_MODE_HALL,
+	FOC_SENSOR_MODE_HFI
+} mc_foc_sensor_mode;
+
+// Auxiliary output mode
+typedef enum {
+	OUT_AUX_MODE_OFF = 0,
+	OUT_AUX_MODE_ON_AFTER_2S,
+	OUT_AUX_MODE_ON_AFTER_5S,
+	OUT_AUX_MODE_ON_AFTER_10S,
+	OUT_AUX_MODE_UNUSED
+} out_aux_mode;
+
+// Temperature sensor type
+typedef enum {
+	TEMP_SENSOR_NTC_10K_25C = 0,
+	TEMP_SENSOR_PTC_1K_100C,
+	TEMP_SENSOR_KTY83_122,
+} temp_sensor_type;
+
+// General purpose drive output mode
+typedef enum {
+	GPD_OUTPUT_MODE_NONE = 0,
+	GPD_OUTPUT_MODE_MODULATION,
+	GPD_OUTPUT_MODE_VOLTAGE,
+	GPD_OUTPUT_MODE_CURRENT
+} gpd_output_mode;
+
+typedef enum {
+	MOTOR_TYPE_BLDC = 0,
+	MOTOR_TYPE_DC,
+	MOTOR_TYPE_FOC,
+	MOTOR_TYPE_GPD
+} mc_motor_type;
+
+// FOC current controller decoupling mode.
+typedef enum {
+	FOC_CC_DECOUPLING_DISABLED = 0,
+	FOC_CC_DECOUPLING_CROSS,
+	FOC_CC_DECOUPLING_BEMF,
+	FOC_CC_DECOUPLING_CROSS_BEMF
+} mc_foc_cc_decoupling_mode;
+
+typedef enum {
+	FOC_OBSERVER_ORTEGA_ORIGINAL = 0,
+	FOC_OBSERVER_ORTEGA_ITERATIVE
+} mc_foc_observer_type;
+
+typedef enum {
+	FAULT_CODE_NONE = 0,
+	FAULT_CODE_OVER_VOLTAGE,
+	FAULT_CODE_UNDER_VOLTAGE,
+	FAULT_CODE_DRV,
+	FAULT_CODE_ABS_OVER_CURRENT,
+	FAULT_CODE_OVER_TEMP_FET,
+	FAULT_CODE_OVER_TEMP_MOTOR,
+	FAULT_CODE_GATE_DRIVER_OVER_VOLTAGE,
+	FAULT_CODE_GATE_DRIVER_UNDER_VOLTAGE,
+	FAULT_CODE_MCU_UNDER_VOLTAGE,
+	FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET,
+	FAULT_CODE_ENCODER_SPI,
+	FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE,
+	FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE,
+	FAULT_CODE_FLASH_CORRUPTION,
+	FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1,
+	FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2,
+	FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3,
+	FAULT_CODE_UNBALANCED_CURRENTS,
+	FAULT_CODE_BRK,
+	FAULT_CODE_RESOLVER_LOT,
+	FAULT_CODE_RESOLVER_DOS,
+	FAULT_CODE_RESOLVER_LOS
+} mc_fault_code;
+
+typedef enum {
+	CONTROL_MODE_DUTY = 0,
+	CONTROL_MODE_SPEED,
+	CONTROL_MODE_CURRENT,
+	CONTROL_MODE_CURRENT_BRAKE,
+	CONTROL_MODE_POS,
+	CONTROL_MODE_HANDBRAKE,
+	CONTROL_MODE_OPENLOOP,
+	CONTROL_MODE_OPENLOOP_PHASE,
+	CONTROL_MODE_OPENLOOP_DUTY,
+	CONTROL_MODE_OPENLOOP_DUTY_PHASE,
+	CONTROL_MODE_NONE
+} mc_control_mode;
+
+typedef enum {
+	DISP_POS_MODE_NONE = 0,
+	DISP_POS_MODE_INDUCTANCE,
+	DISP_POS_MODE_OBSERVER,
+	DISP_POS_MODE_ENCODER,
+	DISP_POS_MODE_PID_POS,
+	DISP_POS_MODE_PID_POS_ERROR,
+	DISP_POS_MODE_ENCODER_OBSERVER_ERROR
+} disp_pos_mode;
+
+typedef enum {
+	SENSOR_PORT_MODE_HALL = 0,
+	SENSOR_PORT_MODE_ABI,
+	SENSOR_PORT_MODE_AS5047_SPI,
+	SENSOR_PORT_MODE_AD2S1205,
+	SENSOR_PORT_MODE_SINCOS,
+	SENSOR_PORT_MODE_TS5700N8501,
+	SENSOR_PORT_MODE_TS5700N8501_MULTITURN
+} sensor_port_mode;
+
+typedef struct {
+	float cycle_int_limit;
+	float cycle_int_limit_running;
+	float cycle_int_limit_max;
+	float comm_time_sum;
+	float comm_time_sum_min_rpm;
+	int32_t comms;
+	float time_at_comm;
+} mc_rpm_dep_struct;
+
+typedef enum {
+	DRV8301_OC_LIMIT = 0,
+	DRV8301_OC_LATCH_SHUTDOWN,
+	DRV8301_OC_REPORT_ONLY,
+	DRV8301_OC_DISABLED
+} drv8301_oc_mode;
+
+typedef enum {
+	DEBUG_SAMPLING_OFF = 0,
+	DEBUG_SAMPLING_NOW,
+	DEBUG_SAMPLING_START,
+	DEBUG_SAMPLING_TRIGGER_START,
+	DEBUG_SAMPLING_TRIGGER_FAULT,
+	DEBUG_SAMPLING_TRIGGER_START_NOSEND,
+	DEBUG_SAMPLING_TRIGGER_FAULT_NOSEND,
+	DEBUG_SAMPLING_SEND_LAST_SAMPLES
+} debug_sampling_mode;
+
+typedef enum {
+	CAN_BAUD_125K = 0,
+	CAN_BAUD_250K,
+	CAN_BAUD_500K,
+	CAN_BAUD_1M,
+	CAN_BAUD_10K,
+	CAN_BAUD_20K,
+	CAN_BAUD_50K,
+	CAN_BAUD_75K
+} CAN_BAUD;
+
+typedef enum {
+	BATTERY_TYPE_LIION_3_0__4_2,
+	BATTERY_TYPE_LIIRON_2_6__3_6,
+	BATTERY_TYPE_LEAD_ACID
+} BATTERY_TYPE;
+
+typedef enum {
+	HFI_SAMPLES_8 = 0,
+	HFI_SAMPLES_16,
+	HFI_SAMPLES_32
+} FOC_HFI_SAMPLES;
+
+typedef struct {
+	// Switching and drive
+	mc_pwm_mode pwm_mode;
+	mc_comm_mode comm_mode;
+	mc_motor_type motor_type;
+	mc_sensor_mode sensor_mode;
+	// Limits
+	float l_current_max;
+	float l_current_min;
+	float l_in_current_max;
+	float l_in_current_min;
+	float l_abs_current_max;
+	float l_min_erpm;
+	float l_max_erpm;
+	float l_erpm_start;
+	float l_max_erpm_fbrake;
+	float l_max_erpm_fbrake_cc;
+	float l_min_vin;
+	float l_max_vin;
+	float l_battery_cut_start;
+	float l_battery_cut_end;
+	bool l_slow_abs_current;
+	float l_temp_fet_start;
+	float l_temp_fet_end;
+	float l_temp_motor_start;
+	float l_temp_motor_end;
+	float l_temp_accel_dec;
+	float l_min_duty;
+	float l_max_duty;
+	float l_watt_max;
+	float l_watt_min;
+	float l_current_max_scale;
+	float l_current_min_scale;
+	float l_duty_start;
+	// Overridden limits (Computed during runtime)
+	float lo_current_max;
+	float lo_current_min;
+	float lo_in_current_max;
+	float lo_in_current_min;
+	float lo_current_motor_max_now;
+	float lo_current_motor_min_now;
+	// Sensorless (bldc)
+	float sl_min_erpm;
+	float sl_min_erpm_cycle_int_limit;
+	float sl_max_fullbreak_current_dir_change;
+	float sl_cycle_int_limit;
+	float sl_phase_advance_at_br;
+	float sl_cycle_int_rpm_br;
+	float sl_bemf_coupling_k;
+	// Hall sensor
+	int8_t hall_table[8];
+	float hall_sl_erpm;
+	// FOC
+	float foc_current_kp;
+	float foc_current_ki;
+	float foc_f_sw;
+	float foc_dt_us;
+	float foc_encoder_offset;
+	bool foc_encoder_inverted;
+	float foc_encoder_ratio;
+	float foc_encoder_sin_offset;
+	float foc_encoder_sin_gain;
+	float foc_encoder_cos_offset;
+	float foc_encoder_cos_gain;
+	float foc_encoder_sincos_filter_constant;
+	float foc_motor_l;
+	float foc_motor_r;
+	float foc_motor_flux_linkage;
+	float foc_observer_gain;
+	float foc_observer_gain_slow;
+	float foc_pll_kp;
+	float foc_pll_ki;
+	float foc_duty_dowmramp_kp;
+	float foc_duty_dowmramp_ki;
+	float foc_openloop_rpm;
+	float foc_sl_openloop_hyst;
+	float foc_sl_openloop_time;
+	float foc_sl_d_current_duty;
+	float foc_sl_d_current_factor;
+	mc_foc_sensor_mode foc_sensor_mode;
+	uint8_t foc_hall_table[8];
+	float foc_sl_erpm;
+	bool foc_sample_v0_v7;
+	bool foc_sample_high_current;
+	float foc_sat_comp;
+	bool foc_temp_comp;
+	float foc_temp_comp_base_temp;
+	float foc_current_filter_const;
+	mc_foc_cc_decoupling_mode foc_cc_decoupling;
+	mc_foc_observer_type foc_observer_type;
+	float foc_hfi_voltage_start;
+	float foc_hfi_voltage_run;
+	float foc_hfi_voltage_max;
+	float foc_sl_erpm_hfi;
+	uint16_t foc_hfi_start_samples;
+	float foc_hfi_obs_ovr_sec;
+	FOC_HFI_SAMPLES foc_hfi_samples;
+	// GPDrive
+	int gpd_buffer_notify_left;
+	int gpd_buffer_interpol;
+	float gpd_current_filter_const;
+	float gpd_current_kp;
+	float gpd_current_ki;
+	// Speed PID
+	float s_pid_kp;
+	float s_pid_ki;
+	float s_pid_kd;
+	float s_pid_kd_filter;
+	float s_pid_min_erpm;
+	bool s_pid_allow_braking;
+	// Pos PID
+	float p_pid_kp;
+	float p_pid_ki;
+	float p_pid_kd;
+	float p_pid_kd_filter;
+	float p_pid_ang_div;
+	// Current controller
+	float cc_startup_boost_duty;
+	float cc_min_current;
+	float cc_gain;
+	float cc_ramp_step_max;
+	// Misc
+	int32_t m_fault_stop_time_ms;
+	float m_duty_ramp_step;
+	float m_current_backoff_gain;
+	uint32_t m_encoder_counts;
+	sensor_port_mode m_sensor_port_mode;
+	bool m_invert_direction;
+	drv8301_oc_mode m_drv8301_oc_mode;
+	int m_drv8301_oc_adj;
+	float m_bldc_f_sw_min;
+	float m_bldc_f_sw_max;
+	float m_dc_f_sw;
+	float m_ntc_motor_beta;
+	out_aux_mode m_out_aux_mode;
+	temp_sensor_type m_motor_temp_sens_type;
+	float m_ptc_motor_coeff;
+	// Setup info
+	uint8_t si_motor_poles;
+	float si_gear_ratio;
+	float si_wheel_diameter;
+	BATTERY_TYPE si_battery_type;
+	int si_battery_cells;
+	float si_battery_ah;
+} mc_configuration;
+
+// Applications to use
+typedef enum {
+	APP_NONE = 0,
+	APP_PPM,
+	APP_ADC,
+	APP_UART,
+	APP_PPM_UART,
+	APP_ADC_UART,
+	APP_NUNCHUK,
+	APP_NRF,
+	APP_CUSTOM,
+	APP_BALANCE
+} app_use;
+
+// Throttle curve mode
+typedef enum {
+	THR_EXP_EXPO = 0,
+	THR_EXP_NATURAL,
+	THR_EXP_POLY
+} thr_exp_mode;
+
+// PPM control types
+typedef enum {
+	PPM_CTRL_TYPE_NONE = 0,
+	PPM_CTRL_TYPE_CURRENT,
+	PPM_CTRL_TYPE_CURRENT_NOREV,
+	PPM_CTRL_TYPE_CURRENT_NOREV_BRAKE,
+	PPM_CTRL_TYPE_DUTY,
+	PPM_CTRL_TYPE_DUTY_NOREV,
+	PPM_CTRL_TYPE_PID,
+	PPM_CTRL_TYPE_PID_NOREV,
+	PPM_CTRL_TYPE_CURRENT_BRAKE_REV_HYST,
+	PPM_CTRL_TYPE_CURRENT_SMART_REV
+} ppm_control_type;
+
+typedef struct {
+	ppm_control_type ctrl_type;
+	float pid_max_erpm;
+	float hyst;
+	float pulse_start;
+	float pulse_end;
+	float pulse_center;
+	bool median_filter;
+	bool safe_start;
+	float throttle_exp;
+	float throttle_exp_brake;
+	thr_exp_mode throttle_exp_mode;
+	float ramp_time_pos;
+	float ramp_time_neg;
+	bool multi_esc;
+	bool tc;
+	float tc_max_diff;
+	float max_erpm_for_dir;
+	float smart_rev_max_duty;
+	float smart_rev_ramp_time;
+} ppm_config;
+
+// ADC control types
+typedef enum {
+	ADC_CTRL_TYPE_NONE = 0,
+	ADC_CTRL_TYPE_CURRENT,
+	ADC_CTRL_TYPE_CURRENT_REV_CENTER,
+	ADC_CTRL_TYPE_CURRENT_REV_BUTTON,
+	ADC_CTRL_TYPE_CURRENT_REV_BUTTON_BRAKE_ADC,
+	ADC_CTRL_TYPE_CURRENT_REV_BUTTON_BRAKE_CENTER,
+	ADC_CTRL_TYPE_CURRENT_NOREV_BRAKE_CENTER,
+	ADC_CTRL_TYPE_CURRENT_NOREV_BRAKE_BUTTON,
+	ADC_CTRL_TYPE_CURRENT_NOREV_BRAKE_ADC,
+	ADC_CTRL_TYPE_DUTY,
+	ADC_CTRL_TYPE_DUTY_REV_CENTER,
+	ADC_CTRL_TYPE_DUTY_REV_BUTTON,
+	ADC_CTRL_TYPE_PID,
+	ADC_CTRL_TYPE_PID_REV_CENTER,
+	ADC_CTRL_TYPE_PID_REV_BUTTON
+} adc_control_type;
+
+typedef struct {
+	adc_control_type ctrl_type;
+	float hyst;
+	float voltage_start;
+	float voltage_end;
+	float voltage_center;
+	float voltage2_start;
+	float voltage2_end;
+	bool use_filter;
+	bool safe_start;
+	bool cc_button_inverted;
+	bool rev_button_inverted;
+	bool voltage_inverted;
+	bool voltage2_inverted;
+	float throttle_exp;
+	float throttle_exp_brake;
+	thr_exp_mode throttle_exp_mode;
+	float ramp_time_pos;
+	float ramp_time_neg;
+	bool multi_esc;
+	bool tc;
+	float tc_max_diff;
+	uint32_t update_rate_hz;
+} adc_config;
+
+// Nunchuk control types
+typedef enum {
+	CHUK_CTRL_TYPE_NONE = 0,
+	CHUK_CTRL_TYPE_CURRENT,
+	CHUK_CTRL_TYPE_CURRENT_NOREV
+} chuk_control_type;
+
+typedef struct {
+	chuk_control_type ctrl_type;
+	float hyst;
+	float ramp_time_pos;
+	float ramp_time_neg;
+	float stick_erpm_per_s_in_cc;
+	float throttle_exp;
+	float throttle_exp_brake;
+	thr_exp_mode throttle_exp_mode;
+	bool multi_esc;
+	bool tc;
+	float tc_max_diff;
+	bool use_smart_rev;
+	float smart_rev_max_duty;
+	float smart_rev_ramp_time;
+} chuk_config;
+
+// NRF Datatypes
+typedef enum {
+	NRF_SPEED_250K = 0,
+	NRF_SPEED_1M,
+	NRF_SPEED_2M
+} NRF_SPEED;
+
+typedef enum {
+	NRF_POWER_M18DBM = 0,
+	NRF_POWER_M12DBM,
+	NRF_POWER_M6DBM,
+	NRF_POWER_0DBM,
+  NRF_POWER_OFF
+} NRF_POWER;
+
+typedef enum {
+	NRF_AW_3 = 0,
+	NRF_AW_4,
+	NRF_AW_5
+} NRF_AW;
+
+typedef enum {
+	NRF_CRC_DISABLED = 0,
+	NRF_CRC_1B,
+	NRF_CRC_2B
+} NRF_CRC;
+
+typedef enum {
+	NRF_RETR_DELAY_250US = 0,
+	NRF_RETR_DELAY_500US,
+	NRF_RETR_DELAY_750US,
+	NRF_RETR_DELAY_1000US,
+	NRF_RETR_DELAY_1250US,
+	NRF_RETR_DELAY_1500US,
+	NRF_RETR_DELAY_1750US,
+	NRF_RETR_DELAY_2000US,
+	NRF_RETR_DELAY_2250US,
+	NRF_RETR_DELAY_2500US,
+	NRF_RETR_DELAY_2750US,
+	NRF_RETR_DELAY_3000US,
+	NRF_RETR_DELAY_3250US,
+	NRF_RETR_DELAY_3500US,
+	NRF_RETR_DELAY_3750US,
+	NRF_RETR_DELAY_4000US
+} NRF_RETR_DELAY;
+
+typedef struct {
+	NRF_SPEED speed;
+	NRF_POWER power;
+	NRF_CRC crc_type;
+	NRF_RETR_DELAY retry_delay;
+	unsigned char retries;
+	unsigned char channel;
+	unsigned char address[3];
+	bool send_crc_ack;
+} nrf_config;
+
+typedef struct {
+	float kp;
+	float ki;
+	float kd;
+	uint16_t hertz;
+	float pitch_fault;
+	float roll_fault;
+	float adc1;
+	float adc2;
+	float overspeed_duty;
+	float tiltback_duty;
+	float tiltback_angle;
+	float tiltback_speed;
+	float tiltback_high_voltage;
+	float tiltback_low_voltage;
+	float startup_pitch_tolerance;
+	float startup_roll_tolerance;
+	float startup_speed;
+	float deadzone;
+	float current_boost;
+	bool multi_esc;
+	float yaw_kp;
+	float yaw_ki;
+	float yaw_kd;
+	float roll_steer_kp;
+	float brake_current;
+	uint16_t overspeed_delay;
+	uint16_t fault_delay;
+	float tiltback_constant;
+	float roll_steer_erpm_kp;
+	float yaw_current_clamp;
+	uint16_t adc_half_fault_erpm;
+	float setpoint_pitch_filter;
+	float setpoint_target_filter;
+	float setpoint_clamp;
+} balance_config;
+
+// CAN status modes
+typedef enum {
+	CAN_STATUS_DISABLED = 0,
+	CAN_STATUS_1,
+	CAN_STATUS_1_2,
+	CAN_STATUS_1_2_3,
+	CAN_STATUS_1_2_3_4,
+	CAN_STATUS_1_2_3_4_5
+} CAN_STATUS_MODE;
+
+typedef enum {
+	SHUTDOWN_MODE_ALWAYS_OFF = 0,
+	SHUTDOWN_MODE_ALWAYS_ON,
+	SHUTDOWN_MODE_TOGGLE_BUTTON_ONLY,
+	SHUTDOWN_MODE_OFF_AFTER_10S,
+	SHUTDOWN_MODE_OFF_AFTER_1M,
+	SHUTDOWN_MODE_OFF_AFTER_5M,
+	SHUTDOWN_MODE_OFF_AFTER_10M,
+	SHUTDOWN_MODE_OFF_AFTER_30M,
+	SHUTDOWN_MODE_OFF_AFTER_1H,
+	SHUTDOWN_MODE_OFF_AFTER_5H,
+} SHUTDOWN_MODE;
+
+typedef enum {
+	IMU_TYPE_OFF = 0,
+	IMU_TYPE_INTERNAL,
+	IMU_TYPE_EXTERNAL_MPU9X50,
+	IMU_TYPE_EXTERNAL_ICM20948,
+	IMU_TYPE_EXTERNAL_BMI160
+} IMU_TYPE;
+
+typedef enum {
+	AHRS_MODE_MADGWICK = 0,
+	AHRS_MODE_MAHONY
+} AHRS_MODE;
+
+typedef struct {
+	IMU_TYPE type;
+	AHRS_MODE mode;
+	int sample_rate_hz;
+	float accel_confidence_decay;
+	float mahony_kp;
+	float mahony_ki;
+	float madgwick_beta;
+	float rot_roll;
+	float rot_pitch;
+	float rot_yaw;
+	float accel_offsets[3];
+	float gyro_offsets[3];
+	float gyro_offset_comp_fact[3];
+	float gyro_offset_comp_clamp;
+} imu_config;
+
+typedef enum {
+	CAN_MODE_VESC = 0,
+	CAN_MODE_UAVCAN,
+	CAN_MODE_COMM_BRIDGE
+} CAN_MODE;
+
+typedef struct {
+	// Settings
+	uint8_t controller_id;
+	uint32_t timeout_msec;
+	float timeout_brake_current;
+	CAN_STATUS_MODE send_can_status;
+	uint32_t send_can_status_rate_hz;
+	CAN_BAUD can_baud_rate;
+	bool pairing_done;
+	bool permanent_uart_enabled;
+	SHUTDOWN_MODE shutdown_mode;
+
+	// CAN modes
+	CAN_MODE can_mode;
+	uint8_t uavcan_esc_index;
+
+	// Application to use
+	app_use app_to_use;
+
+	// PPM application settings
+	ppm_config app_ppm_conf;
+
+	// ADC application settings
+	adc_config app_adc_conf;
+
+	// UART application settings
+	uint32_t app_uart_baudrate;
+
+	// Nunchuk application settings
+	chuk_config app_chuk_conf;
+
+	// NRF application settings
+	nrf_config app_nrf_conf;
+
+	// Balance application settings
+	balance_config app_balance_conf;
+
+	// IMU Settings
+	imu_config imu_conf;
+} app_configuration;
+
+// Communication commands
+typedef enum {
+	COMM_FW_VERSION = 0,
+	COMM_JUMP_TO_BOOTLOADER,
+	COMM_ERASE_NEW_APP,
+	COMM_WRITE_NEW_APP_DATA,
+	COMM_GET_VALUES,
+	COMM_SET_DUTY,
+	COMM_SET_CURRENT,
+	COMM_SET_CURRENT_BRAKE,
+	COMM_SET_RPM,
+	COMM_SET_POS,
+	COMM_SET_HANDBRAKE,
+	COMM_SET_DETECT,
+	COMM_SET_SERVO_POS,
+	COMM_SET_MCCONF,
+	COMM_GET_MCCONF,
+	COMM_GET_MCCONF_DEFAULT,
+	COMM_SET_APPCONF,
+	COMM_GET_APPCONF,
+	COMM_GET_APPCONF_DEFAULT,
+	COMM_SAMPLE_PRINT,
+	COMM_TERMINAL_CMD,
+	COMM_PRINT,
+	COMM_ROTOR_POSITION,
+	COMM_EXPERIMENT_SAMPLE,
+	COMM_DETECT_MOTOR_PARAM,
+	COMM_DETECT_MOTOR_R_L,
+	COMM_DETECT_MOTOR_FLUX_LINKAGE,
+	COMM_DETECT_ENCODER,
+	COMM_DETECT_HALL_FOC,
+	COMM_REBOOT,
+	COMM_ALIVE,
+	COMM_GET_DECODED_PPM,
+	COMM_GET_DECODED_ADC,
+	COMM_GET_DECODED_CHUK,
+	COMM_FORWARD_CAN,
+	COMM_SET_CHUCK_DATA,
+	COMM_CUSTOM_APP_DATA,
+	COMM_NRF_START_PAIRING,
+	COMM_GPD_SET_FSW,
+	COMM_GPD_BUFFER_NOTIFY,
+	COMM_GPD_BUFFER_SIZE_LEFT,
+	COMM_GPD_FILL_BUFFER,
+	COMM_GPD_OUTPUT_SAMPLE,
+	COMM_GPD_SET_MODE,
+	COMM_GPD_FILL_BUFFER_INT8,
+	COMM_GPD_FILL_BUFFER_INT16,
+	COMM_GPD_SET_BUFFER_INT_SCALE,
+	COMM_GET_VALUES_SETUP,
+	COMM_SET_MCCONF_TEMP,
+	COMM_SET_MCCONF_TEMP_SETUP,
+	COMM_GET_VALUES_SELECTIVE,
+	COMM_GET_VALUES_SETUP_SELECTIVE,
+	COMM_EXT_NRF_PRESENT,
+	COMM_EXT_NRF_ESB_SET_CH_ADDR,
+	COMM_EXT_NRF_ESB_SEND_DATA,
+	COMM_EXT_NRF_ESB_RX_DATA,
+	COMM_EXT_NRF_SET_ENABLED,
+	COMM_DETECT_MOTOR_FLUX_LINKAGE_OPENLOOP,
+	COMM_DETECT_APPLY_ALL_FOC,
+	COMM_JUMP_TO_BOOTLOADER_ALL_CAN,
+	COMM_ERASE_NEW_APP_ALL_CAN,
+	COMM_WRITE_NEW_APP_DATA_ALL_CAN,
+	COMM_PING_CAN,
+	COMM_APP_DISABLE_OUTPUT,
+	COMM_TERMINAL_CMD_SYNC,
+	COMM_GET_IMU_DATA,
+	COMM_BM_CONNECT,
+	COMM_BM_ERASE_FLASH_ALL,
+	COMM_BM_WRITE_FLASH,
+	COMM_BM_REBOOT,
+	COMM_BM_DISCONNECT,
+	COMM_BM_MAP_PINS_DEFAULT,
+	COMM_BM_MAP_PINS_NRF5X,
+	COMM_ERASE_BOOTLOADER,
+	COMM_ERASE_BOOTLOADER_ALL_CAN,
+	COMM_PLOT_INIT,
+	COMM_PLOT_DATA,
+	COMM_PLOT_ADD_GRAPH,
+	COMM_PLOT_SET_GRAPH,
+	COMM_GET_DECODED_BALANCE,
+	COMM_BM_MEM_READ,
+	COMM_WRITE_NEW_APP_DATA_LZO,
+	COMM_WRITE_NEW_APP_DATA_ALL_CAN_LZO,
+	COMM_BM_WRITE_FLASH_LZO,
+	COMM_SET_CURRENT_REL,
+	COMM_CAN_FWD_FRAME,
+	COMM_SET_BATTERY_CUT,
+	COMM_SET_BLE_NAME,
+	COMM_SET_BLE_PIN,
+	COMM_SET_CAN_MODE,
+	COMM_GET_IMU_CALIBRATION
+} COMM_PACKET_ID;
+
+// CAN commands
+typedef enum {
+	CAN_PACKET_SET_DUTY = 0,
+	CAN_PACKET_SET_CURRENT,
+	CAN_PACKET_SET_CURRENT_BRAKE,
+	CAN_PACKET_SET_RPM,
+	CAN_PACKET_SET_POS,
+	CAN_PACKET_FILL_RX_BUFFER,
+	CAN_PACKET_FILL_RX_BUFFER_LONG,
+	CAN_PACKET_PROCESS_RX_BUFFER,
+	CAN_PACKET_PROCESS_SHORT_BUFFER,
+	CAN_PACKET_STATUS,
+	CAN_PACKET_SET_CURRENT_REL,
+	CAN_PACKET_SET_CURRENT_BRAKE_REL,
+	CAN_PACKET_SET_CURRENT_HANDBRAKE,
+	CAN_PACKET_SET_CURRENT_HANDBRAKE_REL,
+	CAN_PACKET_STATUS_2,
+	CAN_PACKET_STATUS_3,
+	CAN_PACKET_STATUS_4,
+	CAN_PACKET_PING,
+	CAN_PACKET_PONG,
+	CAN_PACKET_DETECT_APPLY_ALL_FOC,
+	CAN_PACKET_DETECT_APPLY_ALL_FOC_RES,
+	CAN_PACKET_CONF_CURRENT_LIMITS,
+	CAN_PACKET_CONF_STORE_CURRENT_LIMITS,
+	CAN_PACKET_CONF_CURRENT_LIMITS_IN,
+	CAN_PACKET_CONF_STORE_CURRENT_LIMITS_IN,
+	CAN_PACKET_CONF_FOC_ERPMS,
+	CAN_PACKET_CONF_STORE_FOC_ERPMS,
+	CAN_PACKET_STATUS_5,
+	CAN_PACKET_POLL_TS5700N8501_STATUS,
+	CAN_PACKET_CONF_BATTERY_CUT,
+	CAN_PACKET_CONF_STORE_BATTERY_CUT,
+	CAN_PACKET_SHUTDOWN
+} CAN_PACKET_ID;
+
+// Logged fault data
+typedef struct {
+	uint8_t motor;
+	mc_fault_code fault;
+	float current;
+	float current_filtered;
+	float voltage;
+	float gate_driver_voltage;
+	float duty;
+	float rpm;
+	int tacho;
+	int cycles_running;
+	int tim_val_samp;
+	int tim_current_samp;
+	int tim_top;
+	int comm_step;
+	float temperature;
+	int drv8301_faults;
+} fault_data;
+
+// External LED state
+typedef enum {
+	LED_EXT_OFF = 0,
+	LED_EXT_NORMAL,
+	LED_EXT_BRAKE,
+	LED_EXT_TURN_LEFT,
+	LED_EXT_TURN_RIGHT,
+	LED_EXT_BRAKE_TURN_LEFT,
+	LED_EXT_BRAKE_TURN_RIGHT,
+	LED_EXT_BATT
+} LED_EXT_STATE;
+
+typedef struct {
+	int js_x;
+	int js_y;
+	int acc_x;
+	int acc_y;
+	int acc_z;
+	bool bt_c;
+	bool bt_z;
+	bool rev_has_state;
+	bool is_rev;
+} chuck_data;
+
+typedef struct {
+	int id;
+	systime_t rx_time;
+	float rpm;
+	float current;
+	float duty;
+} can_status_msg;
+
+typedef struct {
+	int id;
+	systime_t rx_time;
+	float amp_hours;
+	float amp_hours_charged;
+} can_status_msg_2;
+
+typedef struct {
+	int id;
+	systime_t rx_time;
+	float watt_hours;
+	float watt_hours_charged;
+} can_status_msg_3;
+
+typedef struct {
+	int id;
+	systime_t rx_time;
+	float temp_fet;
+	float temp_motor;
+	float current_in;
+	float pid_pos_now;
+} can_status_msg_4;
+
+typedef struct {
+	int id;
+	systime_t rx_time;
+	float v_in;
+	int32_t tacho_value;
+} can_status_msg_5;
+
+typedef struct {
+	uint8_t js_x;
+	uint8_t js_y;
+	bool bt_c;
+	bool bt_z;
+	bool bt_push;
+	bool rev_has_state;
+	bool is_rev;
+	float vbat;
+} mote_state;
+
+typedef enum {
+	MOTE_PACKET_BATT_LEVEL = 0,
+	MOTE_PACKET_BUTTONS,
+	MOTE_PACKET_ALIVE,
+	MOTE_PACKET_FILL_RX_BUFFER,
+	MOTE_PACKET_FILL_RX_BUFFER_LONG,
+	MOTE_PACKET_PROCESS_RX_BUFFER,
+	MOTE_PACKET_PROCESS_SHORT_BUFFER,
+	MOTE_PACKET_PAIRING_INFO
+} MOTE_PACKET;
+
+typedef struct {
+	float v_in;
+	float temp_mos;
+	float temp_mos_1;
+	float temp_mos_2;
+	float temp_mos_3;
+	float temp_motor;
+    float current_motor;
+    float current_in;
+    float id;
+    float iq;
+    float rpm;
+    float duty_now;
+    float amp_hours;
+    float amp_hours_charged;
+    float watt_hours;
+    float watt_hours_charged;
+    int tachometer;
+    int tachometer_abs;
+    float position;
+    mc_fault_code fault_code;
+    int vesc_id;
+    float vd;
+    float vq;
+} mc_values;
+
+typedef enum {
+	NRF_PAIR_STARTED = 0,
+	NRF_PAIR_OK,
+	NRF_PAIR_FAIL
+} NRF_PAIR_RES;
+
+// Orientation data
+typedef struct {
+	float q0;
+	float q1;
+	float q2;
+	float q3;
+	float integralFBx;
+	float integralFBy;
+	float integralFBz;
+	float accMagP;
+	int initialUpdateDone;
+} ATTITUDE_INFO;
+
+// Custom EEPROM variables
+typedef union {
+	uint32_t as_u32;
+	int32_t as_i32;
+	float as_float;
+} eeprom_var;
+
+#define EEPROM_VARS_HW			64
+#define EEPROM_VARS_CUSTOM		64
+
+typedef struct {
+	float ah_tot;
+	float ah_charge_tot;
+	float wh_tot;
+	float wh_charge_tot;
+	float current_tot;
+	float current_in_tot;
+	uint8_t num_vescs;
+} setup_values;
 }
-VESC_TX_T;
-
-typedef enum
-{
-  FAULT_CODE_NONE = 0,
-  FAULT_CODE_OVER_VOLTAGE,
-  FAULT_CODE_UNDER_VOLTAGE,
-  FAULT_CODE_DRV,
-  FAULT_CODE_ABS_OVER_CURRENT,
-  FAULT_CODE_OVER_TEMP_FET,
-  FAULT_CODE_OVER_TEMP_MOTOR
-}
-mc_fault_code;
-
-typedef enum
-{
-  DISP_POS_MODE_NONE = 0,
-  DISP_POS_MODE_INDUCTANCE,
-  DISP_POS_MODE_OBSERVER,
-  DISP_POS_MODE_ENCODER,
-  DISP_POS_MODE_PID_POS,
-  DISP_POS_MODE_PID_POS_ERROR,
-  DISP_POS_MODE_ENCODER_OBSERVER_ERROR
-}
-disp_pos_mode;
-
-struct MC_VALUES
-{
-public:
-  double v_in;
-  double temp_mos;
-  double temp_motor;
-  double current_motor;
-  double current_in;
-  double id;
-  double iq;
-  double rpm;
-  double duty_now;
-  double amp_hours;
-  double amp_hours_charged;
-  double watt_hours;
-  double watt_hours_charged;
-  int tachometer;
-  int tachometer_abs;
-  double position;
-  mc_fault_code fault_code;
-};
-
-typedef enum
-{
-  DEBUG_SAMPLING_OFF = 0,
-  DEBUG_SAMPLING_NOW,
-  DEBUG_SAMPLING_START,
-  DEBUG_SAMPLING_TRIGGER_START,
-  DEBUG_SAMPLING_TRIGGER_FAULT,
-  DEBUG_SAMPLING_TRIGGER_START_NOSEND,
-  DEBUG_SAMPLING_TRIGGER_FAULT_NOSEND,
-  DEBUG_SAMPLING_SEND_LAST_SAMPLES
-}
-debug_sampling_mode;
-
-typedef enum
-{
-  COMM_FW_VERSION = 0,
-  COMM_JUMP_TO_BOOTLOADER,
-  COMM_ERASE_NEW_APP,
-  COMM_WRITE_NEW_APP_DATA,
-  COMM_GET_VALUES,
-  COMM_SET_DUTY,
-  COMM_SET_CURRENT,
-  COMM_SET_CURRENT_BRAKE,
-  COMM_SET_RPM,
-  COMM_SET_POS,
-  COMM_SET_HANDBRAKE,
-  COMM_SET_DETECT,
-  COMM_SET_SERVO_POS,
-  COMM_SET_MCCONF,
-  COMM_GET_MCCONF,
-  COMM_GET_MCCONF_DEFAULT,
-  COMM_SET_APPCONF,
-  COMM_GET_APPCONF,
-  COMM_GET_APPCONF_DEFAULT,
-  COMM_SAMPLE_PRINT,
-  COMM_TERMINAL_CMD,
-  COMM_PRINT,
-  COMM_ROTOR_POSITION,
-  COMM_EXPERIMENT_SAMPLE,
-  COMM_DETECT_MOTOR_PARAM,
-  COMM_DETECT_MOTOR_R_L,
-  COMM_DETECT_MOTOR_FLUX_LINKAGE,
-  COMM_DETECT_ENCODER,
-  COMM_DETECT_HALL_FOC,
-  COMM_REBOOT,
-  COMM_ALIVE,
-  COMM_GET_DECODED_PPM,
-  COMM_GET_DECODED_ADC,
-  COMM_GET_DECODED_CHUK,
-  COMM_FORWARD_CAN,
-  COMM_SET_CHUCK_DATA,
-  COMM_CUSTOM_APP_DATA,
-  COMM_NRF_START_PAIRING
-}
-COMM_PACKET_ID;
-
-typedef struct
-{
-  int js_x;
-  int js_y;
-  int acc_x;
-  int acc_y;
-  int acc_z;
-  bool bt_c;
-  bool bt_z;
-}
-chuck_data;
-
-struct bldc_detect
-{
-public:
-  double cycle_int_limit;
-  double bemf_coupling_k;
-  int hall_res;
-};
-
-typedef enum
-{
-  NRF_PAIR_STARTED = 0,
-  NRF_PAIR_OK,
-  NRF_PAIR_FAIL
-}
-NRF_PAIR_RES;
-
-}  // namespace vesc_driver
-
-#endif  // VESC_DRIVER__DATATYPES_HPP_
+#endif /* DATATYPES_H_ */

--- a/vesc_driver/include/vesc_driver/vesc_driver.hpp
+++ b/vesc_driver/include/vesc_driver/vesc_driver.hpp
@@ -37,6 +37,9 @@
 #include <vesc_msgs/msg/vesc_state.hpp>
 #include <vesc_msgs/msg/vesc_state_stamped.hpp>
 
+#include <vesc_msgs/msg/vesc_imu.hpp>
+#include <vesc_msgs/msg/vesc_imu_stamped.hpp>
+
 #include <memory>
 #include <string>
 
@@ -49,6 +52,7 @@ namespace vesc_driver
 using std_msgs::msg::Float64;
 using vesc_msgs::msg::VescState;
 using vesc_msgs::msg::VescStateStamped;
+using vesc_msgs::msg::VescImuStamped;
 
 class VescDriver
   : public rclcpp::Node
@@ -87,6 +91,7 @@ private:
 
   // ROS services
   rclcpp::Publisher<VescStateStamped>::SharedPtr state_pub_;
+  rclcpp::Publisher<VescImuStamped>::SharedPtr imu_pub_;
   rclcpp::Publisher<Float64>::SharedPtr servo_sensor_pub_;
   rclcpp::SubscriptionBase::SharedPtr duty_cycle_sub_;
   rclcpp::SubscriptionBase::SharedPtr current_sub_;

--- a/vesc_driver/include/vesc_driver/vesc_interface.hpp
+++ b/vesc_driver/include/vesc_driver/vesc_interface.hpp
@@ -64,6 +64,7 @@ public:
    * @throw SerialException
    */
   VescInterface(
+    const int vesc_id,
     const std::string & port = std::string(),
     const PacketHandlerFunction & packet_handler = PacketHandlerFunction(),
     const ErrorHandlerFunction & error_handler = ErrorHandlerFunction());
@@ -114,19 +115,21 @@ public:
    */
   void send(const VescPacket & packet);
 
-  void requestFWVersion();
-  void requestState();
-  void setDutyCycle(double duty_cycle);
-  void setCurrent(double current);
-  void setBrake(double brake);
-  void setSpeed(double speed);
-  void setPosition(double position);
-  void setServo(double servo);
-
+  void requestFWVersion(int vesc_id);
+  void requestState(int vesc_id);
+  void requestImuData(int vesc_id);
+  void setDutyCycle(int vesc_id,double duty_cycle);
+  void setCurrent(int vesc_id,double current);
+  void setBrake(int vesc_id,double brake);
+  void setSpeed(int vesc_id,double speed);
+  void setPosition(int vesc_id,double position);
+  void setServo(int vesc_id,double servo);
+  
 private:
   // Pimpl - hide serial port members from class users
   class Impl;
   std::unique_ptr<Impl> impl_;
+  const int master_vesc_id_;
 };
 
 // todo: review

--- a/vesc_driver/include/vesc_driver/vesc_packet.hpp
+++ b/vesc_driver/include/vesc_driver/vesc_packet.hpp
@@ -120,6 +120,19 @@ public:
 
   int fwMajor() const;
   int fwMinor() const;
+
+  std::string    hwname() const;
+  const uint8_t* uuid()  const;
+  bool     paired() const;
+  uint8_t  devVersion() const;
+
+ private:
+  int minor_;
+  int major_;
+  std::string hwname_;
+  bool paired_;
+  uint8_t  uuid_[12];
+  uint8_t  devVersion_;
 };
 
 class VescPacketRequestFWVersion : public VescPacket
@@ -135,31 +148,130 @@ class VescPacketValues : public VescPacket
 public:
   explicit VescPacketValues(std::shared_ptr<VescFrame> raw);
 
-  double v_in() const;
-  double temp_mos1() const;
-  double temp_mos2() const;
-  double temp_mos3() const;
-  double temp_mos4() const;
-  double temp_mos5() const;
-  double temp_mos6() const;
-  double temp_pcb() const;
-  double current_motor() const;
-  double current_in() const;
-  double rpm() const;
-  double duty_now() const;
-  double amp_hours() const;
-  double amp_hours_charged() const;
-  double watt_hours() const;
-  double watt_hours_charged() const;
-  double tachometer() const;
-  double tachometer_abs() const;
-  int fault_code() const;
+double  temp_fet() const;
+double  temp_motor() const;
+double  avg_motor_current() const;
+double  avg_input_current() const;
+double  avg_id() const;
+double  avg_iq() const ;
+double  duty_cycle_now() const;
+double  rpm() const;
+double  duty_now() const;
+double  v_in() const;
+double  amp_hours() const;
+double  amp_hours_charged() const;
+double  watt_hours() const;
+double  watt_hours_charged() const;
+int32_t tachometer() const;
+int32_t tachometer_abs() const;
+int     fault_code() const;
+double  pid_pos_now() const;
+int32_t controller_id() const;
+
+double  temp_mos1() const;
+double  temp_mos2() const;
+double  temp_mos3() const;
+double  avg_vd() const;
+double  avg_vq()  const;
+
+int32_t numVescs() const;
+double  watt_battery_left() const;
+
 };
 
 class VescPacketRequestValues : public VescPacket
 {
 public:
   VescPacketRequestValues();
+};
+
+/*------------------------------------------------------------------------------------------------*/
+class VescPacketCanForward : public VescPacket
+{
+public:
+  VescPacketCanForward(std::shared_ptr<VescFrame> raw);
+
+  uint8_t vesc_id() const;
+  VescPacketConstPtr packet() const ;
+} ;
+
+class VescPacketCanForwardRequest : public VescPacket
+{
+public:
+  VescPacketCanForwardRequest(uint8_t vesc_id,const VescPacket &packet);
+} ;
+
+/*---------------------------------*/
+class VescPacketCANFrameForward : public VescPacket
+{
+public:
+  VescPacketCANFrameForward(std::shared_ptr<VescFrame> raw);
+};
+
+/*------------------------------------------------------------------------------------------------*/
+
+class VescPacketRequestImu : public VescPacket
+{
+public:
+  VescPacketRequestImu();
+
+  //  double duty() const;
+};
+
+class VescPacketImu : public VescPacket
+{
+public:
+  VescPacketImu(std::shared_ptr<VescFrame> raw);
+
+  int    mask()  const;
+
+  double yaw()   const ;
+  double pitch() const ;
+  double roll()  const ;
+
+  double acc_x() const ;
+  double acc_y() const ;
+  double acc_z() const ;
+
+  double gyr_x() const ;
+  double gyr_y() const ;
+  double gyr_z() const ;
+
+  double mag_x() const ;
+  double mag_y() const ;
+  double mag_z() const ;
+
+  double q_w() const ;
+  double q_x() const ;
+  double q_y() const ;
+  double q_z() const ;
+
+
+  private:
+    double getFloat32Auto(uint32_t *pos) const;
+
+    
+    uint32_t mask_;
+    double roll_;
+    double pitch_;
+    double yaw_;
+
+    double acc_x_;
+    double acc_y_;
+    double acc_z_;
+
+    double gyr_x_;
+    double gyr_y_;
+    double gyr_z_;
+
+    double mag_x_;
+    double mag_y_;
+    double mag_z_;
+
+    double q0_;
+    double q1_;
+    double q2_;
+    double q3_;
 };
 
 /*------------------------------------------------------------------------------------------------*/

--- a/vesc_driver/launch/vesc_driver_node.launch.xml
+++ b/vesc_driver/launch/vesc_driver_node.launch.xml
@@ -7,7 +7,7 @@
   <let name="launch_prefix" value="xterm -e gdb --args" if="$(var debug)" />
 
   <!-- VESC driver parameters -->
-  <arg name="port" default="/dev/sensors/vesc" />
+  <arg name="port" default="/dev/ttyACM0" />
 
   <!-- VESC driver node -->
   <node pkg="vesc_driver" exec="vesc_driver_node" name="$(var node_name)" output="screen">

--- a/vesc_driver/src/vesc_device_namer.cpp
+++ b/vesc_driver/src/vesc_device_namer.cpp
@@ -1,0 +1,28 @@
+#include <vesc_driver/vesc_device_uuid_lookup.hpp>
+
+#include <stdlib.h> 
+#include <iostream>
+#include <unistd.h>
+
+int main(int argc, char** argv)
+{
+   std::string devicePort=  (argc>0? argv[1]:"");
+   std::string VESC_UUID_ENV="VESC_UUID_ENV=";
+
+   vesc_driver::VescDeviceLookup lookup("/dev/"+devicePort);
+
+   for(int i=0;i<50;i++){
+      usleep(20);
+      if (lookup.isReady()) break;
+
+    }
+    
+    if(lookup.isReady())
+   {
+      VESC_UUID_ENV += lookup.deviceUUID(); 
+      //std::cout << VESC_UUID_ENV <<std::endl;
+      std::cout<<lookup.deviceUUID();
+      setenv("VESC_UUID_ENV",  lookup.deviceUUID(),0 );
+      return 0;
+   } else return -1;
+}

--- a/vesc_driver/src/vesc_device_uuid_lookup.cpp
+++ b/vesc_driver/src/vesc_device_uuid_lookup.cpp
@@ -1,0 +1,84 @@
+#include "vesc_driver/vesc_device_uuid_lookup.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+#include <boost/bind.hpp>
+
+namespace vesc_driver
+{
+
+
+VescDeviceLookup::VescDeviceLookup(std::string name)
+:
+  vesc_(0,
+        std::string(),
+        boost::bind(&VescDeviceLookup::vescPacketCallback, this, _1),
+        boost::bind(&VescDeviceLookup::vescErrorCallback, this, _1)
+       ),
+  ready_(false),
+  device_(name)
+       {
+           //std::cout<<"device port " << device_ << std::endl;
+
+           try {
+                vesc_.connect(device_);
+                vesc_.requestFWVersion(0);
+              }
+              catch (SerialException e) {
+                std::cerr << "VESC error on port "<<device_ << std::endl << e.what() <<std::endl;
+                return;
+              }
+       }
+   
+void VescDeviceLookup::vescPacketCallback(const std::shared_ptr<VescPacket const>& packet){
+       if (packet->name() == "FWVersion") {
+            std::shared_ptr<VescPacketFWVersion const> fw_version =
+              std::dynamic_pointer_cast<VescPacketFWVersion const>(packet);
+            // todo: might need lock here
+            const uint8_t *uuid= fw_version->uuid();
+            
+            hwname_ = fw_version->hwname();
+            version_ = fw_version->fwMajor() + "." + fw_version->fwMinor();
+            char uuid_data[100] ="";
+            //for(int i=0 ;i<12 ;i++)
+            //std::cout << std::hex << std::setfill ('0') << std::setw(2) << (int)uuid[i] << " ";
+
+            //std::cout << std::endl;
+             
+            sprintf(uuid_data, 
+                        "%02x%02x%02x-%02x%02x%02x-%02x%02x%02x-%02x%02x%02x", 
+                            uuid[0], uuid[1], uuid[2], uuid[3], uuid[4], uuid[5], 
+                            
+                            uuid[6], uuid[7], uuid[8], uuid[9], uuid[10], uuid[11]  
+                        );
+             
+             uuid_ += uuid_data;
+             ready_=true;
+          }
+   }
+   
+void VescDeviceLookup::vescErrorCallback(const std::string& error){
+       error_ = error;
+       ready_=false;
+   }
+
+bool VescDeviceLookup::isReady(){
+    return ready_;
+}
+
+const char* VescDeviceLookup::deviceUUID() const{
+      return uuid_.c_str();
+   }
+
+
+    const char* VescDeviceLookup::version() const{
+
+        return version_.c_str();
+    }
+    const char* VescDeviceLookup::hwname() const{
+        return hwname_.c_str();
+    } 
+} 

--- a/vesc_driver/src/vesc_driver.cpp
+++ b/vesc_driver/src/vesc_driver.cpp
@@ -66,7 +66,7 @@ VescDriver::VescDriver(const rclcpp::NodeOptions & options)
   fw_version_minor_(-1)
 {
   // get vesc serial port address
-  std::string port = declare_parameter<std::string>("port", "");
+  std::string port = declare_parameter<std::string>("port", "/tmp/ttyV0");
 
   // attempt to connect to the serial port
   try {
@@ -144,7 +144,7 @@ void VescDriver::timerCallback()
   } else if (driver_mode_ == MODE_OPERATING) {
     // poll for vesc state (telemetry)
     vesc_.requestState(0);
-    //vesc_.requestImuData(0);
+    vesc_.requestImuData(0);
 
   } else {
     // unknown mode, how did that happen?
@@ -243,9 +243,11 @@ void VescDriver::vescPacketCallback(const std::shared_ptr<VescPacket const> & pa
         "%d command value ",
                       vid);
   }
-
-  RCLCPP_INFO(
-        get_logger(), 
+ auto& clk = *this->get_clock();
+  RCLCPP_INFO_THROTTLE(
+        get_logger(),
+        clk,
+        5000, 
         "%s packet received",packet->name().c_str());
 }
 

--- a/vesc_driver/src/vesc_interface.cpp
+++ b/vesc_driver/src/vesc_interface.cpp
@@ -157,8 +157,8 @@ void VescInterface::Impl::rxThread()
       }
     }
 
-    // Only attempt to read every 10 ms
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    // Only attempt to read every 1 ms
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 }
 
@@ -273,25 +273,25 @@ void VescInterface::requestFWVersion(int vesc_id)
   if (master_vesc_id_==vesc_id || vesc_id==0){
     //ROS_INFO("MASTER"); 
      VescPacketRequestFWVersion pay;
-
+/*
      std::cout << "The vector elements are : "<< pay.frame().size() <<std::endl;
      for(int i=0; i < pay.frame().size(); i++)
          std::cout << std::showbase  << std::hex << std::setw(4) << static_cast<int>(pay.frame().at(i)) << " - ";
      
      std::cout <<std::endl <<"--------------------------------------"<<std::endl;
-
+*/
 
      send(pay);
   }else{
      //ROS_INFO("FFW");  
      VescPacketCanForwardRequest  pay(vesc_id,VescPacketRequestFWVersion());
-
+/*
      std::cout << "The vector elements are : "<< pay.frame().size() <<std::endl;
      for(int i=0; i < pay.frame().size(); i++)
          std::cout << std::showbase  << std::hex << std::setw(4) << static_cast<int>(pay.frame().at(i)) << " - ";
      
      std::cout <<std::endl <<"--------------------------------------"<<std::endl;
-
+*/
      send(pay);
   }
 }

--- a/vesc_driver/src/vesc_interface.cpp
+++ b/vesc_driver/src/vesc_interface.cpp
@@ -148,10 +148,12 @@ void VescInterface::Impl::rxThread()
 }
 
 VescInterface::VescInterface(
+  const int vesc_id,
   const std::string & port,
   const PacketHandlerFunction & packet_handler,
   const ErrorHandlerFunction & error_handler)
-: impl_(new Impl())
+: impl_(new Impl()),
+master_vesc_id_(vesc_id)
 {
   setPacketHandler(packet_handler);
   setErrorHandler(error_handler);
@@ -250,44 +252,107 @@ void VescInterface::send(const VescPacket & packet)
   }
 }
 
-void VescInterface::requestFWVersion()
+void VescInterface::requestFWVersion(int vesc_id)
 {
-  send(VescPacketRequestFWVersion());
+
+  if (master_vesc_id_==vesc_id || vesc_id==0){
+    //ROS_INFO("MASTER"); 
+     VescPacketRequestFWVersion pay;
+/*
+     std::cout << "The vector elements are : "<< pay.frame().size() <<std::endl;
+     for(int i=0; i < pay.frame().size(); i++)
+         std::cout << std::showbase  << std::hex << std::setw(4) << static_cast<int>(pay.frame().at(i)) << " - ";
+     
+     std::cout <<std::endl <<"--------------------------------------"<<std::endl;
+*/
+
+     send(pay);
+  }else{
+     //ROS_INFO("FFW");  
+     VescPacketCanForwardRequest  pay(vesc_id,VescPacketRequestFWVersion());
+/*
+     std::cout << "The vector elements are : "<< pay.frame().size() <<std::endl;
+     for(int i=0; i < pay.frame().size(); i++)
+         std::cout << std::showbase  << std::hex << std::setw(4) << static_cast<int>(pay.frame().at(i)) << " - ";
+     
+     std::cout <<std::endl <<"--------------------------------------"<<std::endl;
+*/
+     send(pay);
+  }
 }
 
-void VescInterface::requestState()
+void VescInterface::requestState(int vesc_id)
 {
-  send(VescPacketRequestValues());
+  if (master_vesc_id_==vesc_id || vesc_id==0){
+   send(VescPacketRequestValues());
+  } else {
+   VescPacketCanForwardRequest  pay(vesc_id,VescPacketRequestValues());
+    send(pay);
+  }  
 }
 
-void VescInterface::setDutyCycle(double duty_cycle)
+void VescInterface::setDutyCycle(int vesc_id,double duty_cycle)
 {
-  send(VescPacketSetDuty(duty_cycle));
+  if (master_vesc_id_==vesc_id || vesc_id==0){
+    send(VescPacketSetDuty(duty_cycle));
+    } else {
+    VescPacketCanForwardRequest  pay(vesc_id,VescPacketSetDuty(duty_cycle));
+    send(pay);
+  } 
 }
 
-void VescInterface::setCurrent(double current)
+void VescInterface::setCurrent(int vesc_id,double current)
 {
-  send(VescPacketSetCurrent(current));
+  if (master_vesc_id_==vesc_id || vesc_id==0){
+    send(VescPacketSetCurrent(current));
+    } else {
+    VescPacketCanForwardRequest  pay(vesc_id,VescPacketSetCurrent(current));
+    send(pay);
+  } 
+
+  
 }
 
-void VescInterface::setBrake(double brake)
+void VescInterface::setBrake(int vesc_id,double brake)
 {
-  send(VescPacketSetCurrentBrake(brake));
+  
+  if (master_vesc_id_==vesc_id || vesc_id==0){
+    send(VescPacketSetCurrentBrake(brake));
+    } else {
+    VescPacketCanForwardRequest  pay(vesc_id,VescPacketSetCurrentBrake(brake));
+    send(pay);
+  } 
 }
 
-void VescInterface::setSpeed(double speed)
+void VescInterface::setSpeed(int vesc_id,double speed)
 {
-  send(VescPacketSetRPM(speed));
+  
+  if (master_vesc_id_==vesc_id || vesc_id==0){
+    send(VescPacketSetRPM(speed));
+    } else {
+    VescPacketCanForwardRequest  pay(vesc_id,VescPacketSetRPM(speed));
+    send(pay);
+  }
 }
 
-void VescInterface::setPosition(double position)
+void VescInterface::setPosition(int vesc_id,double position)
 {
-  send(VescPacketSetPos(position));
+  if (master_vesc_id_==vesc_id || vesc_id==0){
+    send(VescPacketSetPos(position));
+    } else {
+    VescPacketCanForwardRequest  pay(vesc_id,VescPacketSetPos(position));
+    send(pay);
+  }
 }
 
-void VescInterface::setServo(double servo)
+void VescInterface::setServo(int vesc_id,double servo)
 {
-  send(VescPacketSetServoPos(servo));
+  if (master_vesc_id_==vesc_id || vesc_id==0){
+    send(VescPacketSetServoPos(servo));
+    } else {
+    VescPacketCanForwardRequest  pay(vesc_id,VescPacketSetServoPos(servo));
+    send(pay);
+  }
 }
 
 }  // namespace vesc_driver

--- a/vesc_driver/src/vesc_packet.cpp
+++ b/vesc_driver/src/vesc_packet.cpp
@@ -37,6 +37,7 @@
 
 #include "vesc_driver/datatypes.hpp"
 #include "vesc_driver/vesc_packet_factory.hpp"
+#include <cmath>
 
 namespace vesc_driver
 {
@@ -100,16 +101,59 @@ VescPacket::VescPacket(const std::string & name, std::shared_ptr<VescFrame> raw)
 VescPacketFWVersion::VescPacketFWVersion(std::shared_ptr<VescFrame> raw)
 : VescPacket("FWVersion", raw)
 {
+
+  major_ = *(payload_.first + 1);
+  minor_ = *(payload_.first + 2); 
+  int j=0;
+  
+
+  for(int i=0;*(payload_.first+3+i)!=0x00;i++){
+      j = i;
+      hwname_ +=  *(payload_.first+3+i);
+   }
+
+  j++;
+  
+  
+  
+ 
+  for(int u=0;u<12;u++){
+    uuid_[u]  = *(payload_.first+3+j+1+u);
+    
+  }
+ 
+
+  paired_ = *(payload_.first+3+j+1+12);
+  devVersion_ = *(payload_.first+3+j+2+12+1);
+
 }
 
 int VescPacketFWVersion::fwMajor() const
 {
-  return *(payload_.first + 1);
+  return major_;
 }
 
 int VescPacketFWVersion::fwMinor() const
 {
-  return *(payload_.first + 2);
+  return minor_;
+}
+
+std::string   VescPacketFWVersion::hwname() const
+{
+  
+   return hwname_.c_str();
+}
+const uint8_t* VescPacketFWVersion::uuid()  const
+{
+  return uuid_;
+}
+bool     VescPacketFWVersion::paired() const
+{
+     return paired_;
+}
+uint8_t  VescPacketFWVersion::devVersion() const
+{
+    return devVersion_;
 }
 
 REGISTER_PACKET_TYPE(COMM_FW_VERSION, VescPacketFWVersion)
@@ -129,120 +173,215 @@ VescPacketValues::VescPacketValues(std::shared_ptr<VescFrame> raw)
 : VescPacket("Values", raw)
 {
 }
+double VescPacketValues::temp_fet() const{
+  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 1)) << 8) +
+                                   static_cast<uint16_t>(*(payload_.first + 2)));
+  return static_cast<double>(v) / 10.0;
+}
+
+double VescPacketValues::temp_motor() const{
+  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 3)) << 8) +
+                                   static_cast<uint16_t>(*(payload_.first + 4)));
+  return static_cast<double>(v) / 10.0;
+}
+
+
+double VescPacketValues::avg_motor_current() const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 5)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 6)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 7)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 8))
+                                     );
+  return static_cast<double>(v) / 100.0;
+
+}
+
+
+double VescPacketValues::avg_input_current()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 9)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 10)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 11)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 12))
+                                     );
+  return static_cast<double>(v) / 100.0;
+
+}
+
+
+double VescPacketValues::avg_id()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 13)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 14)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 15)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 16))
+                                     );
+  return static_cast<double>(v) / 100.0;
+
+}
+
+double VescPacketValues::avg_iq()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 17)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 18)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 19)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 20))
+                                     );
+  return static_cast<double>(v) / 100.0;
+
+}
+
+
+double VescPacketValues::duty_cycle_now() const
+{
+  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 21)) << 8) +
+                                   static_cast<uint16_t>(*(payload_.first + 22)));
+  return static_cast<double>(v) / 1000.0;
+}
+
+double VescPacketValues::rpm()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 23)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 24)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 25)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 26))
+                                     );
+  return static_cast<double>(v) / 1.0;
+
+}
+
+double VescPacketValues::v_in() const
+{
+  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 27)) << 8) +
+                                   static_cast<uint16_t>(*(payload_.first +  28)));
+  return static_cast<double>(v) /10.0;
+}
+
+double VescPacketValues::amp_hours()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 29)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 30)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 31)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 32))
+                                     );
+  return static_cast<double>(v) / 1e4;
+
+}
+
+double VescPacketValues::amp_hours_charged()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 33)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 34)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 35)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 36))
+                                     );
+  return static_cast<double>(v) / 1e4;
+
+}
+
+double VescPacketValues::watt_hours()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 37)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 38)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 39)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 40))
+                                     );
+  return static_cast<double>(v) / 1e4;
+
+}
+
+double VescPacketValues::watt_hours_charged()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 41)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 42)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 43)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 44))
+                                     );
+  return static_cast<double>(v) / 1e4;
+
+}
+
+int32_t VescPacketValues::tachometer() const
+{
+  int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 45)) << 24) +
+                                   (static_cast<uint32_t>(*(payload_.first + 46)) << 16) +
+                                   (static_cast<uint32_t>(*(payload_.first + 47)) << 8) +
+                                   static_cast<uint32_t>(*(payload_.first + 48)));
+  return static_cast<int32_t>(v);
+}
+
+int32_t VescPacketValues::tachometer_abs() const
+{
+  int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 49)) << 24) +
+                                   (static_cast<uint32_t>(*(payload_.first + 50)) << 16) +
+                                   (static_cast<uint32_t>(*(payload_.first + 51)) << 8) +
+                                   static_cast<uint32_t>(*(payload_.first + 52)));
+  return static_cast<int32_t>(v);
+}
+
+int VescPacketValues::fault_code() const
+{
+  return static_cast<int32_t>(*(payload_.first + 53));
+}
+
+
+double VescPacketValues::pid_pos_now() const
+{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 54)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 55)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 56)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 57))
+                                     );
+  return static_cast<double>(v) / 1e6;
+
+}
+
+int32_t VescPacketValues::controller_id() const
+{
+  //int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 58)) << 24) +
+  //                                 (static_cast<uint32_t>(*(payload_.first + 59)) << 16) +
+  //                                 (static_cast<uint32_t>(*(payload_.first + 60)) << 8) +
+  //                                 static_cast<uint32_t>(*(payload_.first + 61)));
+//
+    int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 58) )));
+
+  return static_cast<int32_t>(v);
+}
 
 double VescPacketValues::temp_mos1() const
 {
-  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 1)) << 8) +
-    static_cast<uint16_t>(*(payload_.first + 2)));
+  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 59)) << 8) +
+                                   static_cast<uint16_t>(*(payload_.first + 60)));
   return static_cast<double>(v) / 10.0;
 }
 
 double VescPacketValues::temp_mos2() const
 {
-  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 3)) << 8) +
-    static_cast<uint16_t>(*(payload_.first + 4)));
+  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 61)) << 8) +
+                                   static_cast<uint16_t>(*(payload_.first + 62)));
   return static_cast<double>(v) / 10.0;
 }
 
-double VescPacketValues::current_motor() const
+double VescPacketValues::temp_mos3() const
 {
-  int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 5)) << 24) +
-    (static_cast<uint32_t>(*(payload_.first + 6)) << 16) +
-    (static_cast<uint32_t>(*(payload_.first + 7)) << 8) +
-    static_cast<uint32_t>(*(payload_.first + 8)));
-  return static_cast<double>(v) / 100.0;
+  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 63)) << 8) +
+                                   static_cast<uint16_t>(*(payload_.first + 64)));
+  return static_cast<double>(v) / 10.0;
 }
 
-double VescPacketValues::current_in() const
-{
-  int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 9)) << 24) +
-    (static_cast<uint32_t>(*(payload_.first + 10)) << 16) +
-    (static_cast<uint32_t>(*(payload_.first + 11)) << 8) +
-    static_cast<uint32_t>(*(payload_.first + 12)));
-  return static_cast<double>(v) / 100.0;
+double VescPacketValues::avg_vd()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 65)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 66)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 67)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 68))
+                                     );
+  return static_cast<double>(v) / 1e3;
+
 }
 
 
-double VescPacketValues::duty_now() const
-{
-  int16_t v = static_cast<int16_t>((static_cast<uint16_t>(*(payload_.first + 21)) << 8) +
-    static_cast<uint16_t>(*(payload_.first + 22)));
-  return static_cast<double>(v) / 1000.0;
+double VescPacketValues::avg_vq()  const{
+     int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 69)) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + 70)) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + 71)) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + 72))
+                                     );
+  return static_cast<double>(v) / 1e3;
+
 }
 
-double VescPacketValues::rpm() const
-{
-  int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 23)) << 24) +
-    (static_cast<uint32_t>(*(payload_.first + 24)) << 16) +
-    (static_cast<uint32_t>(*(payload_.first + 25)) << 8) +
-    static_cast<uint32_t>(*(payload_.first + 26)));
-  return static_cast<double>(-1 * v);
-}
-
-double VescPacketValues::amp_hours() const
-{
-  int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 27)) << 24) +
-    (static_cast<uint32_t>(*(payload_.first + 28)) << 16) +
-    (static_cast<uint32_t>(*(payload_.first + 29)) << 8) +
-    static_cast<uint32_t>(*(payload_.first + 30)));
-  return static_cast<double>(v);
-}
-
-double VescPacketValues::amp_hours_charged() const
-{
-  int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 31)) << 24) +
-    (static_cast<uint32_t>(*(payload_.first + 32)) << 16) +
-    (static_cast<uint32_t>(*(payload_.first + 33)) << 8) +
-    static_cast<uint32_t>(*(payload_.first + 34)));
-  return static_cast<double>(v);
-}
-
-double VescPacketValues::tachometer() const
-{
-  int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 35)) << 24) +
-    (static_cast<uint32_t>(*(payload_.first + 36)) << 16) +
-    (static_cast<uint32_t>(*(payload_.first + 37)) << 8) +
-    static_cast<uint32_t>(*(payload_.first + 38)));
-  return static_cast<double>(v);
-}
-
-double VescPacketValues::tachometer_abs() const
-{
-  int32_t v = static_cast<int32_t>((static_cast<uint32_t>(*(payload_.first + 39)) << 24) +
-    (static_cast<uint32_t>(*(payload_.first + 40)) << 16) +
-    (static_cast<uint32_t>(*(payload_.first + 41)) << 8) +
-    static_cast<uint32_t>(*(payload_.first + 42)));
-  return static_cast<double>(v);
-}
-
-int VescPacketValues::fault_code() const
-{
-  return static_cast<int32_t>(*(payload_.first + 56));
-}
-
-double VescPacketValues::v_in() const
-{
-  int32_t v = 0;
-  return static_cast<double>(v);
-}
-
-double VescPacketValues::temp_pcb() const
-{
-  int32_t v = 0;
-  return static_cast<double>(v);
-}
-
-double VescPacketValues::watt_hours() const
-{
-  int32_t v = 0;
-  return static_cast<double>(v);
-}
-
-double VescPacketValues::watt_hours_charged() const
-{
-  int32_t v = 0;
-  return static_cast<double>(v);
-}
 
 REGISTER_PACKET_TYPE(COMM_GET_VALUES, VescPacketValues)
 
@@ -367,5 +506,210 @@ VescPacketSetServoPos::VescPacketSetServoPos(double servo_pos)
   *(frame_->end() - 3) = static_cast<uint8_t>(crc >> 8);
   *(frame_->end() - 2) = static_cast<uint8_t>(crc & 0xFF);
 }
+
+VescPacketImu::VescPacketImu(std::shared_ptr<VescFrame> raw) :
+    VescPacket("ImuData", raw)
+  {
+
+      uint32_t ind=1;
+      mask_ = static_cast<uint32_t>(
+               (static_cast<uint16_t>(*(payload_.first + ind       )) << 8) +
+                static_cast<uint16_t>(*(payload_.first + ind + 1   ))
+              ) ;
+      ind+=2;
+      
+      if(mask_ & ((uint32_t)1 << 0)) 
+        roll_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 1)) 
+        pitch_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 2)) 
+        yaw_ = getFloat32Auto(&ind);
+      
+
+      if(mask_ & ((uint32_t)1 << 3)) 
+        acc_x_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 4)) 
+        acc_y_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 5)) 
+        acc_z_ = getFloat32Auto(&ind);
+
+
+      if(mask_ & ((uint32_t)1 << 6)) 
+        gyr_x_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 7)) 
+        gyr_y_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 8)) 
+        gyr_z_ = getFloat32Auto(&ind);
+
+      if(mask_ & ((uint32_t)1 << 9)) 
+        mag_x_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 10)) 
+        mag_y_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 11)) 
+        mag_z_ = getFloat32Auto(&ind);
+
+
+      if(mask_ & ((uint32_t)1 << 12)) 
+        q0_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 13)) 
+        q1_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 14)) 
+        q2_ = getFloat32Auto(&ind);
+      if(mask_ & ((uint32_t)1 << 15)) 
+        q3_ = getFloat32Auto(&ind);       
+  }
+
+
+  int    VescPacketImu::mask() const{
+    return mask_;
+  }
+
+  double VescPacketImu::getFloat32Auto(uint32_t *idx) const {
+        int pos= *idx;
+        uint32_t res = static_cast<uint32_t>(
+                                      (static_cast<uint32_t>(*(payload_.first + (pos ) )) << 24) +
+                                      (static_cast<uint32_t>(*(payload_.first + (pos + 1) )) << 16) +
+                                      (static_cast<uint32_t>(*(payload_.first + (pos + 2) )) << 8) +
+                                       static_cast<uint32_t>(*(payload_.first + (pos + 3) ))
+                                     );
+    *idx +=4;
+    int e = (res >> 23) & 0xFF;
+    int fr = res & 0x7FFFFF;
+    bool negative = res & (1 << 31);
+
+    float f = 0.0;
+    if (e != 0 || fr != 0) {
+        f = (float)fr / (8388608.0 * 2.0) + 0.5;
+        e -= 126;
+    }
+
+    if (negative) {
+        f = -f;
+    }
+
+    return ldexpf(f, e);
+  }
+
+
+
+  double VescPacketImu::roll() const  {
+   return roll_*180/M_PI; // da rad a gradi per debug  deg
+  };
+
+  double VescPacketImu::pitch() const {
+    return pitch_*180/M_PI;
+  };
+
+
+  double VescPacketImu::yaw() const {
+     return yaw_*180/M_PI;
+  };
+
+
+  double VescPacketImu::acc_x()const  {
+   return acc_x_; // g/s
+  };
+
+  double VescPacketImu::acc_y() const  {
+   return acc_y_;
+  };
+  double VescPacketImu::acc_z() const  {
+   return acc_z_;
+  };
+
+  double VescPacketImu::gyr_x() const  {
+    return gyr_x_;//deg/s
+  };
+  double VescPacketImu::gyr_y() const  {
+    return gyr_y_;
+  };
+  double VescPacketImu::gyr_z() const  {
+   return gyr_z_;
+  };
+
+  double VescPacketImu::mag_x() const  {
+    return mag_x_;
+  };
+  double VescPacketImu::mag_y() const  {
+    return mag_y_;
+  };
+  double VescPacketImu::mag_z() const  {
+   return mag_z_;
+  };
+
+  double VescPacketImu::q_w() const  {
+    return q0_;
+  };
+  double VescPacketImu::q_x() const  {
+    return q1_;    
+  };
+  double VescPacketImu::q_y() const  {
+   return q2_;
+  };
+  double VescPacketImu::q_z() const  {
+   return q3_;
+  };
+
+ 
+REGISTER_PACKET_TYPE(COMM_GET_IMU_DATA, VescPacketImu)
+
+VescPacketRequestImu::VescPacketRequestImu() :
+  VescPacket("RequestImuData", 3, COMM_GET_IMU_DATA)
+{
+  *(payload_.first + 1) = static_cast<uint8_t>(0xFF);
+  *(payload_.first + 2) = static_cast<uint8_t>(0xFF);
+
+
+  uint16_t crc = CRC::Calculate(
+    &(*payload_.first), std::distance(payload_.first, payload_.second), VescFrame::CRC_TYPE);
+  *(frame_->end() - 3) = static_cast<uint8_t>(crc >> 8);
+  *(frame_->end() - 2) = static_cast<uint8_t>(crc & 0xFF);
+}
+
+
+
+/*------------------------------------------------------------------------------------------------*/
+
+  VescPacketCanForward::VescPacketCanForward(std::shared_ptr<VescFrame> raw) :
+  VescPacket("CanForward", raw)
+  {
+
+  }
+
+  uint8_t VescPacketCanForward::vesc_id()  const {
+    return *(payload_.first+1);
+  }
+  VescPacketConstPtr VescPacketCanForward::packet() const {
+       int bytes_needed = VescFrame::VESC_MIN_FRAME_SIZE;
+       std::string error;
+       return VescPacketFactory::createPacket(frame().begin()+2,frame().end(), &bytes_needed,&error);
+  }
+
+ REGISTER_PACKET_TYPE(COMM_FORWARD_CAN, VescPacketCanForward)
+
+  VescPacketCanForwardRequest::VescPacketCanForwardRequest(uint8_t vesc_id,const VescPacket &packet):
+  VescPacket("CanForwardRequest",std::distance(packet.frame().begin(),packet.frame().end())-5+2,COMM_FORWARD_CAN){
+      
+      *(payload_.first +1) = vesc_id;
+
+      /* take payload and copy to forward */
+      vesc_driver::Buffer a =packet.frame();
+      std::copy (a.begin()+2, a.end()-3, payload_.first +2);
+      /* calculate new crc */
+      uint16_t crc = CRC::Calculate(
+        &(*payload_.first), std::distance(payload_.first, payload_.second), VescFrame::CRC_TYPE);
+      *(frame_->end() - 3) = static_cast<uint8_t>(crc >> 8);
+      *(frame_->end() - 2) = static_cast<uint8_t>(crc & 0xFF);
+
+  }
+
+  VescPacketCANFrameForward::VescPacketCANFrameForward(std::shared_ptr<VescFrame> raw):
+  VescPacket("CanFrameForward",raw)
+  {
+
+  }
+
+  REGISTER_PACKET_TYPE(COMM_CAN_FWD_FRAME, VescPacketCANFrameForward)
+
 
 }  // namespace vesc_driver

--- a/vesc_driver/vesc_device_lookup
+++ b/vesc_driver/vesc_device_lookup
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH=/opt/ros/foxy/lib 
+
+vesc_device_namer $1

--- a/vesc_msgs/CMakeLists.txt
+++ b/vesc_msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ rosidl_generate_interfaces(vesc_msgs
   DEPENDENCIES
     builtin_interfaces
     std_msgs
+    geometry_msgs
 )
 
 if(BUILD_TESTING)

--- a/vesc_msgs/CMakeLists.txt
+++ b/vesc_msgs/CMakeLists.txt
@@ -7,6 +7,8 @@ ament_auto_find_build_dependencies()
 rosidl_generate_interfaces(vesc_msgs
   "msg/VescState.msg"
   "msg/VescStateStamped.msg"
+  "msg/VescImu.msg"
+  "msg/VescImuStamped.msg"
   DEPENDENCIES
     builtin_interfaces
     std_msgs

--- a/vesc_msgs/msg/VescImu.msg
+++ b/vesc_msgs/msg/VescImu.msg
@@ -1,0 +1,8 @@
+
+#int32                  mask
+geometry_msgs/Vector3  ypr
+geometry_msgs/Vector3  linear_acceleration
+geometry_msgs/Vector3  angular_velocity
+
+geometry_msgs/Vector3  compass
+geometry_msgs/Quaternion orientation

--- a/vesc_msgs/msg/VescImuStamped.msg
+++ b/vesc_msgs/msg/VescImuStamped.msg
@@ -1,0 +1,4 @@
+
+
+std_msgs/Header  header
+VescImu imu

--- a/vesc_msgs/msg/VescState.msg
+++ b/vesc_msgs/msg/VescState.msg
@@ -9,16 +9,33 @@ int32 FAULT_CODE_ABS_OVER_CURRENT=4
 int32 FAULT_CODE_OVER_TEMP_FET=5
 int32 FAULT_CODE_OVER_TEMP_MOTOR=6
 
+# follow the bledc firwmare: commands.c
+float64 temp_fet             # fet temperature 
+float64 temp_motor           # motor temperature
+float64 current_motor        # motor current (ampere) avg_motor_current
+float64 current_input        # input current (ampere) avg_input_current          
+float64 avg_id
+float64 avg_iq
+float64 duty_cycle           # duty cycle (0 to 1) duty_cycle_now
+float64 speed                # motor electrical speed (revolutions per minute) rpm
+
 float64 voltage_input        # input voltage (volt)
-float64 temperature_pcb      # temperature of printed circuit board (degrees Celsius)
-float64 current_motor        # motor current (ampere)
-float64 current_input        # input current (ampere)
-float64 speed                # motor electrical speed (revolutions per minute) 
-float64 duty_cycle           # duty cycle (0 to 1)
-float64 charge_drawn         # electric charge drawn from input (ampere-hour)
-float64 charge_regen         # electric charge regenerated to input (ampere-hour)
+float64 charge_drawn         # electric charge drawn from input (ampere-hours)
+float64 charge_regen         # electric charge regenerated to input (ampere-hour) amp_hours_charged    
 float64 energy_drawn         # energy drawn from input (watt-hour)
-float64 energy_regen         # energy regenerated to input (watt-hour)
-float64 displacement         # net tachometer (counts)
-float64 distance_traveled    # total tachnometer (counts)
+float64 energy_regen         # energy regenerated to input (watt_hours_charged)
+int32   displacement         # net tachometer (counts) tachometer
+int32   distance_traveled    # total tachnometer (counts) tachometer_abs
 int32   fault_code
+
+float64 pid_pos_now
+int32 controller_id
+
+
+float64 ntc_temp_mos1
+float64 ntc_temp_mos2
+float64 ntc_temp_mos3
+float64 avg_vd
+float64 avg_vq
+
+#float64 temperature_pcb      # temperature of printed circuit board (degrees Celsius)

--- a/vesc_msgs/package.xml
+++ b/vesc_msgs/package.xml
@@ -19,6 +19,7 @@
   <build_depend>rosidl_default_generators</build_depend>
   <depend>builtin_interfaces</depend>
   <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
- protocol adapted to firmware 5.2
- fixed bug that prevented the reading of data from the serial
- added reading of imu data
- added program to enumerate vescs based on their uuid
- added possibility to command more vesc through canForward