### PR TITLE
Corrected error in vesc_to_odom.cpp

### DIFF
--- a/vesc_ackermann/src/vesc_to_odom.cpp
+++ b/vesc_ackermann/src/vesc_to_odom.cpp
@@ -42,6 +42,7 @@ namespace vesc_ackermann
 using geometry_msgs::msg::TransformStamped;
 using nav_msgs::msg::Odometry;
 using std::placeholders::_1;
+using std_msgs::msg::Float64;
 using vesc_msgs::msg::VescStateStamped;
 
 VescToOdom::VescToOdom(const rclcpp::NodeOptions & options)
@@ -83,7 +84,7 @@ VescToOdom::VescToOdom(const rclcpp::NodeOptions & options)
     "sensors/core", 10, std::bind(&VescToOdom::vescStateCallback, this, _1));
 
   if (use_servo_cmd_) {
-    servo_sub_ = create_subscription<VescStateStamped>(
+    servo_sub_ = create_subscription<Float64>(
       "sensors/servo_position_command", 10, std::bind(&VescToOdom::servoCmdCallback, this, _1));
   }
 }


### PR DESCRIPTION
In `vesc_to_odom.cpp`, the data type of the message should be `Float` not `VescStateStamped`. This error prevents the `odom` and `tf` from being published. This merge corrects the error.