### PR TITLE
[Bug Fix] Use synchronous serial read

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,7 @@
 
 Packages to interface with Veddar VESC motor controllers. See https://vesc-project.com/ for details
 
-# Development Log
-Haoru Xue 8/6/2021
-
-Completed:
-
-- Fall back to C++ 14
-- Enabled error handler
-
-
-Haoru Xue 5/16/2021
-
-Completed:
-
-- Ported the VESC package to ROS2
-- Sensor reading tested
-- Speed and steerign commands tested
-
-Potential Improvements:
-
-- C++ 17 is currently required to replace `boost::optional` with `std::optional`
-- Speed sensor reading is inverted
-- Not made LifeCycleNode yet
+This is a ROS2 implementation of the ROS1 driver using the new serial driver located in [transport drivers](https://github.com/ros-drivers/transport_drivers).
 
 ## How to test
 
@@ -33,5 +12,6 @@ Potential Improvements:
 2. `rosdep update && rosdep install --from-paths src -i -y`
 3. Plug in the VESC with a USB cable.
 4. Modify `vesc/vesc_driver/params/vesc_config.yaml` to reflect any changes.
-5. Build the package `colcon build`
+5. Build the packages `colcon build`
 6. `ros2 launch vesc_driver vesc_driver_node.launch.py`
+7. If prompted "permission denied" on the serial port: `sudo chmod 777 /dev/ttyACM0`

--- a/vesc_driver/src/vesc_driver.cpp
+++ b/vesc_driver/src/vesc_driver.cpp
@@ -249,7 +249,7 @@ void VescDriver::vescPacketCallback(const std::shared_ptr<VescPacket const> & pa
     imu_std_pub_->publish(std_imu_msg);
   }
   auto & clk = *this->get_clock();
-  RCLCPP_INFO_THROTTLE(
+  RCLCPP_DEBUG_THROTTLE(
     get_logger(),
     clk,
     5000,


### PR DESCRIPTION
As discovered by Mitsudome, the vesc state report and IMU report framerate is not stable. I find this to be related to how the serial driver in ROS2 transport driver handles async serial receive in which there are corrupted buffer data. This fix switches to sync receive and use the size of data received for copying into buffer. Framerate is tested to be stable at 50Hz for both IMU and vesc state.

This fix also brings back the old error handler in ROS1 version of the driver to signal transmission issues.

Also fixed:

- Update README
- Reduce severity of a constant print statement to debug