### PR TITLE
Expose VESC config from VESC driver launch file.

### DIFF
--- a/vesc_driver/launch/vesc_driver_node.launch.py
+++ b/vesc_driver/launch/vesc_driver_node.launch.py
@@ -30,6 +30,8 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -41,11 +43,16 @@ def generate_launch_description():
         'vesc_config.yaml'
         )
     return LaunchDescription([
+        DeclareLaunchArgument(
+            name="config",
+            default_value=vesc_config,
+            description="VESC yaml configuration file.",
+            ),
         Node(
             package='vesc_driver',
             executable='vesc_driver_node',
             name='vesc_driver_node',
-            parameters=[vesc_config]
+            parameters=[LaunchConfiguration("config")]
         ),
 
     ])


### PR DESCRIPTION
Before the `vesc_driver_node.launch.py`  was not flexible.
A user should manually modify the config contained in this ros package to use this launch file. This is not convenient because forces each user to create a fork of this repository for each vesc instance he has.

This PR expose the `vesc_config` as an input argument of the launch file. In this way, the user can keep the configuration of the vesc in a separate folder.

This is not breaking any interface because we keep the default value to the `vesc_config.yaml` contained in the vesc driver.