### PR TITLE
Add ci for ros 2 Humble.

### DIFF
--- a/.github/workflows/ros2-ci.yaml
+++ b/.github/workflows/ros2-ci.yaml
@@ -11,9 +11,19 @@ on:
 jobs:
 
   build-ros2:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+          ros_distro: "humble"
+        }
+        - {
+          ros_distro: "foxy"
+        }
     runs-on: ubuntu-latest
     container:
-      image: ros:foxy
+      image: ros:${{ matrix.config.ros_distro }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Adding ros2 humble to the CI workflow since is the new long term Distro.

This PR is also keeping ros2 Foxy since it is still supported until May 2023 (https://docs.ros.org/en/humble/Releases.html)
