### PR TITLE
Standardize vesc speed to m/s conversion.

### DIFF
--- a/vesc_ackermann/src/vesc_to_odom.cpp
+++ b/vesc_ackermann/src/vesc_to_odom.cpp
@@ -99,7 +99,7 @@ void VescToOdom::vescStateCallback(const VescStateStamped::SharedPtr state)
   }
 
   // convert to engineering units
-  double current_speed = (-state->state.speed - speed_to_erpm_offset_) / speed_to_erpm_gain_;
+  double current_speed = (state->state.speed - speed_to_erpm_offset_) / speed_to_erpm_gain_;
   if (std::fabs(current_speed) < 0.05) {
     current_speed = 0.0;
   }


### PR DESCRIPTION
Before this commit the vesc_to_odom node and the ackermann_to_vesc_node were using a different formula for converting m/s to erpm.


The conversion from m/s to erpm is done [here](https://github.com/f1tenth/vesc/blob/153998df8545fe1781b975df88e411b4e71d4bfe/vesc_ackermann/src/ackermann_to_vesc.cpp#L75) with the following formula:

```
servo_msg.data = steering_to_servo_gain_ * cmd->drive.steering_angle + steering_to_servo_offset_;
````

Inverting this formula leads to:
```
(servo_msg.data - steering_to_servo_offset_)/steering_to_servo_gain_  = cmd->drive.steering_angle ;
````
so for consistency, it would be better to remove the minus sign from the conversion in the vesc to odom node and use the vesc tool to configure the vesc to provide the information with the correct direction.


