### PR TITLE
add dependency for asio_cmake_module in package.xml

### DIFF
--- a/vesc_driver/package.xml
+++ b/vesc_driver/package.xml
@@ -22,6 +22,7 @@
   <depend>std_msgs</depend>
   <depend>vesc_msgs</depend>
   <depend>serial_driver</depend>
+  <depend>asio_cmake_module</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
For docker builds that build from the base ros2 image and want to install all dependencies using rosdep, the asio_cmake_module reference is missing. Adding it to the package.xml in the vesc_driver fixes the issue.