### PR TITLE
Add dependency on asio_cmake_module in package.xml

### DIFF
--- a/vesc_driver/package.xml
+++ b/vesc_driver/package.xml
@@ -24,6 +24,7 @@
   <depend>vesc_msgs</depend>
   <depend>serial_driver</depend>
   <depend>sensor_msgs</depend>
+  <depend>asio_cmake_module</depend>
 
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
For docker builds that build from the base ros2 image and want to install all dependencies using rosdep, the asio_cmake_module reference is missing. Adding it to the package.xml in the vesc_driver fixes the issue.